### PR TITLE
Fix YouTube video url

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,7 @@ ReflexBehaviors.devtools.start()
 
 
 ## Introductory Video
-[![IMAGE ALT TEXT HERE](https://img.youtube.com/vi/WERDPzOz1sA/maxresdefault.jpg)]([https://www.youtube.com/watch?v=WERDPzOz1sA](https://www.youtube.com/watch?v=WERDPzOz1sA))
-
-
+[![Watch the introduction on YouTube](https://img.youtube.com/vi/WERDPzOz1sA/maxresdefault.jpg)](https://youtu.be/WERDPzOz1sA "Watch the introduction on YouTube")
 
 
 


### PR DESCRIPTION
The previous version was opening the image instead of the YouTube video.
This should open the YouTube video correctly.