### PR TITLE
Multiple toggle targets

### DIFF
--- a/app/commands/turbo_boost/elements/toggle_command.rb
+++ b/app/commands/turbo_boost/elements/toggle_command.rb
@@ -7,9 +7,13 @@ class TurboBoost::Elements::ToggleCommand < TurboBoost::Elements::ApplicationCom
     validate_element!
 
     if element.remember?
-      state[element.aria.controls] = true
+      element.aria.controls.split(" ").each do |controls|
+        state[controls] = true
+      end
     else
-      state.now[element.aria.controls] = true
+      element.aria.controls.split(" ").each do |controls|
+        state.now[controls] = true
+      end
     end
 
     morph id: element.morphs, html: render(element.render_options)
@@ -17,7 +21,11 @@ class TurboBoost::Elements::ToggleCommand < TurboBoost::Elements::ApplicationCom
 
   def hide
     validate_element!
-    state[element.aria.controls] = false
+
+    element.aria.controls.split(" ").each do |controls|
+      state[controls] = false
+    end
+
     morph id: element.morphs, html: render(element.render_options)
   end
 

--- a/app/javascript/elements/toggle_elements/target_element/index.js
+++ b/app/javascript/elements/toggle_elements/target_element/index.js
@@ -102,6 +102,7 @@ export default class ToggleTargetElement extends ToggleElement {
 
   // all triggers
   get triggerElements () {
+    // TODO we'll have to improve this to find any trigger element that contains this ID in its space separated LIST of aria-controls
     return document.querySelectorAll(`[aria-controls="${this.id}"]`)
   }
 

--- a/app/javascript/elements/toggle_elements/trigger_element/index.js
+++ b/app/javascript/elements/toggle_elements/trigger_element/index.js
@@ -51,8 +51,12 @@ export default class ToggleTriggerElement extends ToggleElement {
 
   onCommandStart (event) {
     currentFocusSelector = this.focusSelector
-    this.targetElement.labeledBy = this.id
-    this.targetElement.collapseMatches()
+    this.targetElements.forEach(element => {
+      element.labeledBy = this.id
+    })
+    this.targetElements.forEach(element => {
+      element.collapseMatches()
+    })
     this.busy = true
     // TODO: implement cache - this.targetElement.renderCachedHTML()
   }
@@ -116,7 +120,7 @@ export default class ToggleTriggerElement extends ToggleElement {
 
   // the target's dom_id
   get controls () {
-    return this.getAttribute('aria-controls')
+    return this.getAttribute('aria-controls').split(' ')
   }
 
   get collapseSelector () {
@@ -169,8 +173,16 @@ export default class ToggleTriggerElement extends ToggleElement {
 
   // the target element
   get targetElement () {
-    if (!this.controls) return null
-    return document.getElementById(this.controls)
+    if (this.targetElements.length == 0) return null
+    return this.targetElements[0]
+  }
+
+  // all targets
+  get targetElements () {
+    if (!this.controls) return []
+    return document.querySelectorAll(
+      `${this.controls.map(controls => `#${controls}`).join(', ')}`
+    )
   }
 
   get triggerTooltipData () {
@@ -186,7 +198,7 @@ export default class ToggleTriggerElement extends ToggleElement {
     return {
       subtitle: `
       <b>id</b>: ${this.triggerElement.id}<br>
-      <b>aria-controls</b>: ${this.triggerElement.controls}<br>
+      <b>aria-controls</b>: ${this.triggerElement.controls.join(', ')}<br>
       <b>aria-expanded</b>: ${this.triggerElement.expanded}<br>
       <b>remember</b>: ${this.triggerElement.remember}<br>
     `,

--- a/lib/turbo_boost/elements/tag_builders/toggle_tags_builder.rb
+++ b/lib/turbo_boost/elements/tag_builders/toggle_tags_builder.rb
@@ -28,7 +28,7 @@ class TurboBoost::Elements::TagBuilders::ToggleTagsBuilder < TurboBoost::Element
     &block # a Ruby block that emits this trigger's content
   )
     kwargs = kwargs.with_indifferent_access
-    kwargs[:id] ||= "#{controls}-toggle-trigger"
+    kwargs[:id] ||= "#{Array(controls).join(" ").parameterize}-toggle-trigger"
 
     # command
     kwargs[:data] ||= {}

--- a/lib/turbo_boost/elements/tag_builders/toggle_tags_builder.rb
+++ b/lib/turbo_boost/elements/tag_builders/toggle_tags_builder.rb
@@ -82,7 +82,7 @@ class TurboBoost::Elements::TagBuilders::ToggleTagsBuilder < TurboBoost::Element
   end
 
   def target_expanded?(dom_id)
-    !!controller_pack.state[dom_id]
+    Array(dom_id).any? { |dom_id| !!controller_pack.state[dom_id] }
   end
 
   def target_collapsed?(dom_id)


### PR DESCRIPTION
This PR allows to toggle multiple targets in a way that adheres to the [aria-controls specification](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls) 🎉 

Specifically, I've expanded the `targetElement` to a list of elements defined by a list of IDs in `aria-controls` where applicable.

Here's a quick example repo: https://github.com/julianrubisch/turbo_boost-elements-test. Firing this up and adding a post, you should get this:


https://github.com/hopsoft/turbo_boost-elements/assets/4352208/523dbe3d-7c15-40f7-a162-4fd604b20432

There's a final TODO I haven't yet tackled: https://github.com/hopsoft/turbo_boost-elements/compare/main...julianrubisch:turbo_boost-elements:multiple-toggle-targets?expand=1#diff-cb87972fc68e152400f137350beab0650332a06e765d64044854eb6c6a4a0f78R105

Also, to stay consistent with the single-item case, I check whether any of the controlled DOM ids is expanded: https://github.com/hopsoft/turbo_boost-elements/compare/main...julianrubisch:turbo_boost-elements:multiple-toggle-targets?expand=1#diff-0d05fcbb54bf4cb3d6e33827837c58e3ef26562c08cb80740721a5110eb09257R85 - Should this be an `.all?` ? I should note that I've not yet thought about the "mixed" case, where some elements are expanded and others aren't.

We will have to tend to the devtools separately, they're currently only pointing at the first `targetElement`.