### PR TITLE
fix(js): allow pinning importmaps with gem

### DIFF
--- a/lib/turbo_boost/elements/engine.rb
+++ b/lib/turbo_boost/elements/engine.rb
@@ -11,11 +11,19 @@ module TurboBoost::Elements
 
   class Engine < ::Rails::Engine
     isolate_namespace TurboBoost::Elements
+
     config.turbo_boost_elements = ActiveSupport::OrderedOptions.new
+    config.turbo_boost_elements.precompile_assets = true
 
     ActiveSupport.on_load(:action_controller_base) do
       # `self` is ActionController::Base
       helper TurboBoost::Elements::ApplicationHelper
+    end
+
+    config.after_initialize do |app|
+      if app.config.respond_to?(:assets) && app.config.turbo_boost_elements.precompile_assets
+        app.config.assets.precompile += %w[@turbo-boost/elements.js]
+      end
     end
   end
 end


### PR DESCRIPTION
Since import maps JSPM and the javascript ecosystem are a mess in their current state, allow import maps to match the assets served by the gem rather than download them from JSPM.

```ruby
pin "@turbo-boost/streams", to: "@turbo-boost/streams.js", preload: false
pin "@turbo-boost/commands", to: "@turbo-boost/commands.js", preload: false
pin "@turbo-boost/elements", to: "@turbo-boost/elements.js", preload: false
pin "alpinejs", preload: false # @3.13.5
pin "@alpinejs/morph", to: "@alpinejs--morph.js", preload: false # @3.13.5
```

That fixes that problem; I'm happy with this solution for now; seems fair since JSPM never updates. Perhaps we can update the documentation for importmaps to the following:

1. https://github.com/hopsoft/turbo_boost-streams/pull/51
2. https://github.com/hopsoft/turbo_boost-commands/pull/122
3. https://github.com/hopsoft/turbo_boost-elements/pull/49

This is verified to be working with: 

```ruby
gem "turbo_boost-streams",  github: "mhenrixon/turbo_boost-streams"
gem "turbo_boost-commands", github: "mhenrixon/turbo_boost-commands"
gem "turbo_boost-elements", github: "mhenrixon/turbo_boost-elements"
```